### PR TITLE
Changed accuracy step to allow decimal values

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             $("#accuracy_input_wrapper").hide();
             $("#accuracy_slider").slider({
                 value: 90,
+                step: 0.1,
                 slide: function(event, ui) {
                     calculateValues();
                 }


### PR DESCRIPTION
Since the twitter thread that started it all starts exactly with a
decimal value for accuracy (99.5%), this changes the step of the
slider, allowing decimal values.